### PR TITLE
[SYCL] Refactor kernel and kernel_impl classes (#829)

### DIFF
--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -14,6 +14,7 @@
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_t.hpp>
+#include <CL/sycl/device.hpp>
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/range.hpp>

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -11,12 +11,14 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/program_manager/program_manager.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <memory>
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -16,6 +16,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/event.hpp>

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -267,31 +267,9 @@ PARAM_TRAITS_SPEC(event_profiling, command_submit, cl_ulong)
 PARAM_TRAITS_SPEC(event_profiling, command_start, cl_ulong)
 PARAM_TRAITS_SPEC(event_profiling, command_end, cl_ulong)
 
-PARAM_TRAITS_SPEC(kernel, function_name, string_class)
-PARAM_TRAITS_SPEC(kernel, num_args, cl_uint)
-PARAM_TRAITS_SPEC(kernel, reference_count, cl_uint)
-PARAM_TRAITS_SPEC(kernel, attributes, string_class)
-// Shilei: The following two traits are not covered in the current version of
-// CTS (SYCL-1.2.1/master)
-PARAM_TRAITS_SPEC(kernel, context, cl::sycl::context)
-PARAM_TRAITS_SPEC(kernel, program, cl::sycl::program)
-
-PARAM_TRAITS_SPEC(kernel_work_group, compile_work_group_size,
-                  cl::sycl::range<3>)
-PARAM_TRAITS_SPEC(kernel_work_group, global_work_size, cl::sycl::range<3>)
-PARAM_TRAITS_SPEC(kernel_work_group, preferred_work_group_size_multiple, size_t)
-PARAM_TRAITS_SPEC(kernel_work_group, private_mem_size, cl_ulong)
-PARAM_TRAITS_SPEC(kernel_work_group, work_group_size, size_t)
-
-PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, max_sub_group_size_for_ndrange,
-                             size_t, cl::sycl::range<3>)
-PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, sub_group_count_for_ndrange,
-                             size_t, cl::sycl::range<3>)
-PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, local_size_for_sub_group_count,
-                             cl::sycl::range<3>, size_t)
-PARAM_TRAITS_SPEC(kernel_sub_group, max_num_sub_groups, size_t)
-PARAM_TRAITS_SPEC(kernel_sub_group, compile_num_sub_groups, size_t)
-PARAM_TRAITS_SPEC(kernel_sub_group, compile_sub_group_size, size_t)
+#include <CL/sycl/info/kernel_sub_group_traits.def>
+#include <CL/sycl/info/kernel_traits.def>
+#include <CL/sycl/info/kernel_work_group_traits.def>
 
 PARAM_TRAITS_SPEC(platform, profile, string_class)
 PARAM_TRAITS_SPEC(platform, version, string_class)
@@ -308,6 +286,7 @@ PARAM_TRAITS_SPEC(queue, context, cl::sycl::context)
 PARAM_TRAITS_SPEC(queue, device, cl::sycl::device)
 
 #undef PARAM_TRAITS_SPEC
+#undef PARAM_TRAITS_SPEC_WITH_INPUT
 
 } // namespace info
 } // namespace sycl

--- a/sycl/include/CL/sycl/info/kernel_sub_group_traits.def
+++ b/sycl/include/CL/sycl/info/kernel_sub_group_traits.def
@@ -1,0 +1,10 @@
+PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, max_sub_group_size_for_ndrange,
+                             size_t, cl::sycl::range<3>)
+PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, sub_group_count_for_ndrange,
+                             size_t, cl::sycl::range<3>)
+PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, local_size_for_sub_group_count,
+                             cl::sycl::range<3>, size_t)
+PARAM_TRAITS_SPEC(kernel_sub_group, max_num_sub_groups, size_t)
+PARAM_TRAITS_SPEC(kernel_sub_group, compile_num_sub_groups, size_t)
+PARAM_TRAITS_SPEC(kernel_sub_group, compile_sub_group_size, size_t)
+

--- a/sycl/include/CL/sycl/info/kernel_traits.def
+++ b/sycl/include/CL/sycl/info/kernel_traits.def
@@ -1,0 +1,7 @@
+PARAM_TRAITS_SPEC(kernel, function_name, string_class)
+PARAM_TRAITS_SPEC(kernel, num_args, cl_uint)
+PARAM_TRAITS_SPEC(kernel, reference_count, cl_uint)
+PARAM_TRAITS_SPEC(kernel, attributes, string_class)
+PARAM_TRAITS_SPEC(kernel, context, cl::sycl::context)
+PARAM_TRAITS_SPEC(kernel, program, cl::sycl::program)
+

--- a/sycl/include/CL/sycl/info/kernel_work_group_traits.def
+++ b/sycl/include/CL/sycl/info/kernel_work_group_traits.def
@@ -1,0 +1,7 @@
+PARAM_TRAITS_SPEC(kernel_work_group, compile_work_group_size,
+                  cl::sycl::range<3>)
+PARAM_TRAITS_SPEC(kernel_work_group, global_work_size, cl::sycl::range<3>)
+PARAM_TRAITS_SPEC(kernel_work_group, preferred_work_group_size_multiple, size_t)
+PARAM_TRAITS_SPEC(kernel_work_group, private_mem_size, cl_ulong)
+PARAM_TRAITS_SPEC(kernel_work_group, work_group_size, size_t)
+

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include <CL/sycl/detail/kernel_impl.hpp>
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <memory>
@@ -18,77 +19,121 @@ namespace sycl {
 // Forward declaration
 class program;
 class context;
+namespace detail {
+class kernel_impl;
+}
 
 class kernel {
+public:
+  /// Constructs a SYCL kernel instance from an OpenCL cl_kernel
+  ///
+  /// The requirements for this constructor are described in section 4.3.1
+  /// of the SYCL specification.
+  ///
+  /// @param ClKernel is a valid OpenCL cl_kernel instance
+  /// @param SyclContext is a valid SYCL context
+  kernel(cl_kernel ClKernel, const context &SyclContext);
+
+  kernel(const kernel &RHS) = default;
+
+  kernel(kernel &&RHS) = default;
+
+  kernel &operator=(const kernel &RHS) = default;
+
+  kernel &operator=(kernel &&RHS) = default;
+
+  bool operator==(const kernel &RHS) const { return impl == RHS.impl; }
+
+  bool operator!=(const kernel &RHS) const { return !operator==(RHS); }
+
+  /// Get a valid OpenCL kernel handle
+  ///
+  /// If this kernel encapsulates an instance of OpenCL kernel, a valid
+  /// cl_kernel will be returned. If this kernel is a host kernel,
+  /// an invalid_object_error exception will be thrown.
+  ///
+  /// @return a valid cl_kernel instance
+  cl_kernel get() const;
+
+  /// Check if the associated SYCL context is a SYCL host context.
+  ///
+  /// @return true if this SYCL kernel is a host kernel.
+  bool is_host() const;
+
+  /// Get the context that this kernel is defined for.
+  ///
+  /// The value returned must be equal to that returned by
+  /// get_info<info::kernel::context>().
+  ///
+  /// @return a valid SYCL context
+  context get_context() const;
+
+  /// Get the program that this kernel is defined for.
+  ///
+  /// The value returned must be equal to that returned by
+  /// get_info<info::kernel::program>().
+  ///
+  /// @return a valid SYCL program
+  program get_program() const;
+
+  /// Query information from the kernel object using the info::kernel_info
+  /// descriptor.
+  ///
+  /// @return depends on information being queried.
+  template <info::kernel param>
+  typename info::param_traits<info::kernel, param>::return_type
+  get_info() const;
+
+  /// Query work-group information from a kernel using the
+  /// info::kernel_work_group descriptor for a specific device.
+  ///
+  /// @param Device is a valid SYCL device.
+  /// @return depends on information being queried.
+  template <info::kernel_work_group param>
+  typename info::param_traits<info::kernel_work_group, param>::return_type
+  get_work_group_info(const device &Device) const;
+
+  /// Query sub-group information from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device.
+  ///
+  /// @param Device is a valid SYCL device.
+  /// @return depends on information being queried.
+  template <info::kernel_sub_group param>
+  typename info::param_traits<info::kernel_sub_group, param>::return_type
+  get_sub_group_info(const device &Device) const;
+
+  /// Query sub-group information from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device and value.
+  ///
+  /// @param Device is a valid SYCL device.
+  /// @param Value depends on information being queried.
+  /// @return depends on information being queried.
+  template <info::kernel_sub_group param>
+  typename info::param_traits<info::kernel_sub_group, param>::return_type
+  get_sub_group_info(
+      const device &Device,
+      typename info::param_traits<info::kernel_sub_group, param>::input_type
+          Value) const;
+
+private:
+  /// Constructs a SYCL kernel object from a valid kernel_impl instance.
+  kernel(std::shared_ptr<detail::kernel_impl> Impl);
+
+  shared_ptr_class<detail::kernel_impl> impl;
+
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
-
-public:
-  kernel(cl_kernel clKernel, const context &syclContext)
-      : impl(std::make_shared<detail::kernel_impl>(
-            detail::pi::cast<detail::RT::PiKernel>(clKernel), syclContext)) {}
-
-  kernel(const kernel &rhs) = default;
-
-  kernel(kernel &&rhs) = default;
-
-  kernel &operator=(const kernel &rhs) = default;
-
-  kernel &operator=(kernel &&rhs) = default;
-
-  bool operator==(const kernel &rhs) const { return impl == rhs.impl; }
-
-  bool operator!=(const kernel &rhs) const { return !operator==(rhs); }
-
-  cl_kernel get() const { return impl->get(); }
-
-  bool is_host() const { return impl->is_host(); }
-
-  context get_context() const { return impl->get_context(); }
-
-  program get_program() const;
-
-  template <info::kernel param>
-  typename info::param_traits<info::kernel, param>::return_type
-  get_info() const {
-    return impl->get_info<param>();
-  }
-
-  template <info::kernel_work_group param>
-  typename info::param_traits<info::kernel_work_group, param>::return_type
-  get_work_group_info(const device &dev) const {
-    return impl->get_work_group_info<param>(dev);
-  }
-
-  template <info::kernel_sub_group param>
-  typename info::param_traits<info::kernel_sub_group, param>::return_type
-  get_sub_group_info(const device &dev) const {
-    return impl->get_sub_group_info<param>(dev);
-  }
-
-  template <info::kernel_sub_group param>
-  typename info::param_traits<info::kernel_sub_group, param>::return_type
-  get_sub_group_info(const device &dev,
-                     typename info::param_traits<info::kernel_sub_group,
-                                                 param>::input_type val) const {
-    return impl->get_sub_group_info<param>(dev, val);
-  }
-
-private:
-  kernel(std::shared_ptr<detail::kernel_impl> impl) : impl(impl) {}
-
-  std::shared_ptr<detail::kernel_impl> impl;
 };
 } // namespace sycl
 } // namespace cl
 
 namespace std {
 template <> struct hash<cl::sycl::kernel> {
-  size_t operator()(const cl::sycl::kernel &k) const {
+  size_t operator()(const cl::sycl::kernel &Kernel) const {
     return hash<std::shared_ptr<cl::sycl::detail::kernel_impl>>()(
-        cl::sycl::detail::getSyclObjImpl(k));
+        cl::sycl::detail::getSyclObjImpl(Kernel));
   }
 };
 } // namespace std

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -6,10 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl/detail/kernel_impl.hpp>
-
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
+#include <CL/sycl/detail/kernel_info.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/program.hpp>
+
 #include <memory>
 
 namespace cl {
@@ -21,17 +23,118 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext)
                   std::make_shared<program_impl>(SyclContext, Kernel),
                   /*IsCreatedFromSource*/ true) {}
 
-program kernel_impl::get_program() const {
-  return createSyclObjFromImpl<program>(ProgramImpl);
+kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
+                         std::shared_ptr<program_impl> ProgramImpl,
+                         bool IsCreatedFromSource)
+    : MKernel(Kernel), MContext(SyclContext),
+      MProgramImpl(std::move(ProgramImpl)),
+      MCreatedFromSource(IsCreatedFromSource) {
+
+  RT::PiContext Context = nullptr;
+  PI_CALL(RT::piKernelGetInfo, MKernel, CL_KERNEL_CONTEXT, sizeof(Context),
+          &Context, nullptr);
+  auto ContextImpl = detail::getSyclObjImpl(SyclContext);
+  if (ContextImpl->getHandleRef() != Context)
+    throw cl::sycl::invalid_parameter_error(
+        "Input context must be the same as the context of cl_kernel");
+  PI_CALL(RT::piKernelRetain, MKernel);
+}
+
+kernel_impl::kernel_impl(const context &SyclContext,
+                         std::shared_ptr<program_impl> ProgramImpl)
+    : MContext(SyclContext), MProgramImpl(std::move(ProgramImpl)) {}
+
+kernel_impl::~kernel_impl() {
+  // TODO catch an exception and put it to list of asynchronous exceptions
+  if (!is_host()) {
+    PI_CALL(RT::piKernelRelease, MKernel);
+  }
+}
+
+template <info::kernel param>
+typename info::param_traits<info::kernel, param>::return_type
+kernel_impl::get_info() const {
+  if (is_host()) {
+    // TODO implement
+    assert(0 && "Not implemented");
+  }
+  return get_kernel_info<
+      typename info::param_traits<info::kernel, param>::return_type,
+      param>::_(this->getHandleRef());
 }
 
 template <> context kernel_impl::get_info<info::kernel::context>() const {
-  return get_context();
+  return MContext;
 }
 
 template <> program kernel_impl::get_info<info::kernel::program>() const {
-  return get_program();
+  return createSyclObjFromImpl<program>(MProgramImpl);
 }
+
+template <info::kernel_work_group param>
+typename info::param_traits<info::kernel_work_group, param>::return_type
+kernel_impl::get_work_group_info(const device &Device) const {
+  if (is_host()) {
+    return get_kernel_work_group_info_host<param>(Device);
+  }
+  return get_kernel_work_group_info<
+      typename info::param_traits<info::kernel_work_group, param>::return_type,
+      param>::_(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
+}
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel_impl::get_sub_group_info(const device &Device) const {
+  if (is_host()) {
+    throw runtime_error("Sub-group feature is not supported on HOST device.");
+  }
+  return get_kernel_sub_group_info<
+      typename info::param_traits<info::kernel_sub_group, param>::return_type,
+      param>::_(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
+}
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel_impl::get_sub_group_info(
+    const device &Device,
+    typename info::param_traits<info::kernel_sub_group, param>::input_type
+        Value) const {
+  if (is_host()) {
+    throw runtime_error("Sub-group feature is not supported on HOST device.");
+  }
+  return get_kernel_sub_group_info_with_input<
+      typename info::param_traits<info::kernel_sub_group, param>::return_type,
+      param,
+      typename info::param_traits<info::kernel_sub_group, param>::input_type>::
+      _(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(), Value);
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel_impl::get_info<info::param_type::param>() const;
+
+#include <CL/sycl/info/kernel_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel_impl::get_work_group_info<info::param_type::param>( \
+      const device &) const;
+
+#include <CL/sycl/info/kernel_work_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel_impl::get_sub_group_info<info::param_type::param>(  \
+      const device &) const;
+#define PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type, in_type)     \
+  template ret_type kernel_impl::get_sub_group_info<info::param_type::param>(  \
+      const device &, in_type) const;
+
+#include <CL/sycl/info/kernel_sub_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+#undef PARAM_TRAITS_SPEC_WITH_INPUT
 
 bool kernel_impl::isCreatedFromSource() const {
   // TODO it is not clear how to understand whether the SYCL kernel is created
@@ -46,7 +149,7 @@ bool kernel_impl::isCreatedFromSource() const {
   // kernel SecondKernel = kernel(ClKernel, Context);
   // clReleaseKernel(ClKernel);
   // FirstKernel.isCreatedFromSource() != FirstKernel.isCreatedFromSource();
-  return IsCreatedFromSource;
+  return MCreatedFromSource;
 }
 
 } // namespace detail

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -885,7 +885,7 @@ cl_int ExecCGCommand::enqueueImp() {
     RT::PiKernel Kernel = nullptr;
 
     if (nullptr != ExecKernel->MSyclKernel) {
-      assert(ExecKernel->MSyclKernel->get_context() == Context);
+      assert(ExecKernel->MSyclKernel->get_info<info::kernel::context>() == Context);
       Kernel = ExecKernel->MSyclKernel->getHandleRef();
     } else
       Kernel = detail::ProgramManager::getInstance().getOrCreateKernel(

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -6,14 +6,84 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/kernel.hpp>
-
 #include <CL/sycl/program.hpp>
 
 namespace cl {
 namespace sycl {
 
-program kernel::get_program() const { return impl->get_program(); }
+kernel::kernel(cl_kernel ClKernel, const context &SyclContext)
+    : impl(std::make_shared<detail::kernel_impl>(
+          detail::pi::cast<detail::RT::PiKernel>(ClKernel), SyclContext)) {}
+
+cl_kernel kernel::get() const { return impl->get(); }
+
+bool kernel::is_host() const { return impl->is_host(); }
+
+context kernel::get_context() const {
+  return impl->get_info<info::kernel::context>();
+}
+
+program kernel::get_program() const {
+  return impl->get_info<info::kernel::program>();
+}
+
+template <info::kernel param>
+typename info::param_traits<info::kernel, param>::return_type
+kernel::get_info() const {
+  return impl->get_info<param>();
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel::get_info<info::param_type::param>() const;
+
+#include <CL/sycl/info/kernel_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+template <info::kernel_work_group param>
+typename info::param_traits<info::kernel_work_group, param>::return_type
+kernel::get_work_group_info(const device &dev) const {
+  return impl->get_work_group_info<param>(dev);
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel::get_work_group_info<info::param_type::param>(      \
+      const device &) const;
+
+#include <CL/sycl/info/kernel_work_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel::get_sub_group_info(const device &dev) const {
+  return impl->get_sub_group_info<param>(dev);
+}
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel::get_sub_group_info(
+    const device &dev,
+    typename info::param_traits<info::kernel_sub_group, param>::input_type val)
+    const {
+  return impl->get_sub_group_info<param>(dev, val);
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel::get_sub_group_info<info::param_type::param>(       \
+      const device &) const;
+#define PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type, in_type)     \
+  template ret_type kernel::get_sub_group_info<info::param_type::param>(       \
+      const device &, in_type) const;
+
+#include <CL/sycl/info/kernel_sub_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+#undef PARAM_TRAITS_SPEC_WITH_INPUT
+
+kernel::kernel(std::shared_ptr<detail::kernel_impl> Impl) : impl(Impl) {}
 
 } // namespace sycl
 } // namespace cl


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library interface from its actual implementation. The goal is to improve SYCL ABI/API compatibility between different versions of library.

The following modifications were applied to kernel and kernel_impl classes:

1. Removed include of kernel_impl header from kernel.hpp and replaced it with forward declaration.
1. Move member function implementations from kernel.hpp to kernel.cpp
1. Documentation was improved for both kernel and kernel_impl
1. kernel_impl now tries to follow LLVM code style
1. Replace std::shared_ptr with shared_ptr_class for kernel class

Applying aforementioned changes requires modifying other header files. While some of those may seem as a regression, affected classes will be covered by future patches.

Signed-off-by: Alexander Batashev alexander.batashev@intel.com